### PR TITLE
Fixed module loading error

### DIFF
--- a/PortPlacement/PortPlacement.py
+++ b/PortPlacement/PortPlacement.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 from __main__ import vtk, qt, ctk, slicer
-
+import string
 #
 # PortPlacement
 #


### PR DESCRIPTION
Slicer core changed to import module into separate namespace and therefore string module has to be imported explicitly
